### PR TITLE
App module

### DIFF
--- a/simple-task-list/src/app/app.module.ts
+++ b/simple-task-list/src/app/app.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms'; // Required for ngModel
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, FormsModule],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}


### PR DESCRIPTION
Since ngModel is used for two-way binding, FormsModule is imported.